### PR TITLE
US11: Bookcover WebClient

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,11 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webflux</artifactId>
+			<version>6.0.10</version>
+		</dependency>
+		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>
 			<artifactId>de.flapdoodle.embed.mongo.spring30x</artifactId>
 			<scope>test</scope>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -49,6 +49,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>4.11.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/controller/BookCoverController.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/controller/BookCoverController.java
@@ -1,12 +1,11 @@
 package de.neuefische.readandmeet.backend.controller;
 
+import de.neuefische.readandmeet.backend.model.BookCoverInfo;
 import de.neuefische.readandmeet.backend.service.BookCoverService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -18,9 +17,8 @@ public class BookCoverController {
         this.bookCoverService = bookCoverService;
     }
 
-    @GetMapping("/bookcovers")
-    public List<String> fetchAndGenerateCoverUrls(@RequestParam String title, @RequestParam String author) {
-        return bookCoverService.fetchAndGenerateCoverUrls(title, author);
+    @GetMapping("/bookcover")
+    public BookCoverInfo fetchFirstCoverInfo(@RequestParam String title, @RequestParam String author) {
+        return bookCoverService.fetchFirstCoverInfo(title, author);
     }
-
 }

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/controller/BookCoverController.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/controller/BookCoverController.java
@@ -1,0 +1,26 @@
+package de.neuefische.readandmeet.backend.controller;
+
+import de.neuefische.readandmeet.backend.service.BookCoverService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class BookCoverController {
+
+    private final BookCoverService bookCoverService;
+
+    public BookCoverController(BookCoverService bookCoverService) {
+        this.bookCoverService = bookCoverService;
+    }
+
+    @GetMapping("/bookcovers")
+    public List<String> fetchAndGenerateCoverUrls(@RequestParam String title, @RequestParam String author) {
+        return bookCoverService.fetchAndGenerateCoverUrls(title, author);
+    }
+
+}

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
@@ -1,11 +1,8 @@
 package de.neuefische.readandmeet.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
-@Data
-@AllArgsConstructor
+
 public class BookCoverDoc {
 
     @JsonProperty("cover_i")

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
@@ -12,4 +12,6 @@ public class BookCoverDoc {
         return coverId;
     }
 
+    public void setCoverId(int i) {
+    }
 }

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
@@ -1,7 +1,11 @@
 package de.neuefische.readandmeet.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
+@Data
+@AllArgsConstructor
 public class BookCoverDoc {
 
     @JsonProperty("cover_i")

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
@@ -12,6 +12,7 @@ public class BookCoverDoc {
         return coverId;
     }
 
-    public void setCoverId(int i) {
+    public void setCoverId(int coverId) {
+        this.coverId = coverId;
     }
 }

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverDoc.java
@@ -2,7 +2,7 @@ package de.neuefische.readandmeet.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class SearchDoc {
+public class BookCoverDoc {
 
     @JsonProperty("cover_i")
     private Integer coverId;
@@ -11,7 +11,4 @@ public class SearchDoc {
         return coverId;
     }
 
-    public void setCoverId(Integer coverId) {
-        this.coverId = coverId;
-    }
 }

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverInfo.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/BookCoverInfo.java
@@ -1,0 +1,20 @@
+package de.neuefische.readandmeet.backend.model;
+
+
+public class BookCoverInfo {
+    private Integer coverId;
+    private String coverUrl;
+
+    public BookCoverInfo(Integer coverId, String coverUrl) {
+        this.coverId = coverId;
+        this.coverUrl = coverUrl;
+    }
+
+    public Integer getCoverId() {
+        return coverId;
+    }
+
+    public String getCoverUrl() {
+        return coverUrl;
+    }
+}

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
@@ -7,14 +7,9 @@ import java.util.List;
 public class OpenLibrarySearchResponse {
 
     @JsonProperty("docs")
-    private List<SearchDoc> docs;
+    private List<BookCoverDoc> docs;
 
-    public List<SearchDoc> getDocs() {
+    public List<BookCoverDoc> getDocs() {
         return docs;
     }
-
-    public void setDocs(List<SearchDoc> docs) {
-        this.docs = docs;
-    }
-
 }

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
@@ -1,0 +1,20 @@
+package de.neuefische.readandmeet.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class OpenLibrarySearchResponse {
+
+    @JsonProperty("docs")
+    private List<SearchDoc> docs;
+
+    public List<SearchDoc> getDocs() {
+        return docs;
+    }
+
+    public void setDocs(List<SearchDoc> docs) {
+        this.docs = docs;
+    }
+
+}

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
@@ -1,9 +1,12 @@
 package de.neuefische.readandmeet.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 import java.util.List;
-
+@Data
+@AllArgsConstructor
 public class OpenLibrarySearchResponse {
 
     @JsonProperty("docs")

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
@@ -12,4 +12,8 @@ public class OpenLibrarySearchResponse {
     public List<BookCoverDoc> getDocs() {
         return docs;
     }
+
+    public void setDocs(List<BookCoverDoc> docs) {
+        this.docs = docs;
+    }
 }

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponse.java
@@ -1,12 +1,9 @@
 package de.neuefische.readandmeet.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.List;
-@Data
-@AllArgsConstructor
+
 public class OpenLibrarySearchResponse {
 
     @JsonProperty("docs")

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/model/SearchDoc.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/model/SearchDoc.java
@@ -1,0 +1,17 @@
+package de.neuefische.readandmeet.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SearchDoc {
+
+    @JsonProperty("cover_i")
+    private Integer coverId;
+
+    public Integer getCoverId() {
+        return coverId;
+    }
+
+    public void setCoverId(Integer coverId) {
+        this.coverId = coverId;
+    }
+}

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/service/BookCoverService.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/service/BookCoverService.java
@@ -3,6 +3,7 @@ package de.neuefische.readandmeet.backend.service;
 import de.neuefische.readandmeet.backend.model.BookCoverDoc;
 import de.neuefische.readandmeet.backend.model.BookCoverInfo;
 import de.neuefische.readandmeet.backend.model.OpenLibrarySearchResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -16,8 +17,10 @@ public class BookCoverService {
 
     private final WebClient webClient;
 
-    public BookCoverService(WebClient.Builder webClientBuilder) {
-        this.webClient = webClientBuilder.baseUrl("https://openlibrary.org").build();
+    public BookCoverService(
+            @Value("${bookcover-api.url}") String url
+    ) {
+        this.webClient = WebClient.create(url);
     }
 
     public BookCoverInfo fetchFirstCoverInfo(String title, String author) {

--- a/backend/src/main/java/de/neuefische/readandmeet/backend/service/BookCoverService.java
+++ b/backend/src/main/java/de/neuefische/readandmeet/backend/service/BookCoverService.java
@@ -1,0 +1,64 @@
+package de.neuefische.readandmeet.backend.service;
+
+import de.neuefische.readandmeet.backend.model.OpenLibrarySearchResponse;
+import de.neuefische.readandmeet.backend.model.SearchDoc;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class BookCoverService {
+
+    private final WebClient webClient;
+
+    public BookCoverService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl("https://openlibrary.org").build();
+    }
+
+    public List<String> fetchAndGenerateCoverUrls(String title, String author) {
+        List<Integer> coverIds = fetchCoverIds(title, author);
+        return generateCoverUrls(coverIds);
+    }
+
+    public List<Integer> fetchCoverIds(String title, String author) {
+        ResponseEntity<OpenLibrarySearchResponse> responseEntity = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/search.json")
+                        .queryParam("q", title + " " + author)
+                        .build())
+                .retrieve()
+                .toEntity(OpenLibrarySearchResponse.class)
+                .block();
+
+        List<Integer> coverIds = new ArrayList<>();
+        OpenLibrarySearchResponse searchResponse = Objects.requireNonNull(responseEntity).getBody();
+
+        if (searchResponse != null) {
+            List<SearchDoc> docs = searchResponse.getDocs();
+            for (SearchDoc doc : docs) {
+                if (doc.getCoverId() != null) {
+                    coverIds.add(doc.getCoverId());
+                }
+            }
+        }
+
+        return coverIds;
+    }
+
+
+    public List<String> generateCoverUrls(List<Integer> coverIds) {
+        List<String> coverUrls = new ArrayList<>();
+
+        for (Integer coverId : coverIds) {
+            String coverUrl = String.format("https://covers.openlibrary.org/b/id/%d-M.jpg", coverId);
+            coverUrls.add(coverUrl);
+        }
+
+        return coverUrls;
+    }
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.data.mongodb.uri=${MONGO_DB_URI}
+bookcover-api.url=https://openlibrary.org

--- a/backend/src/test/java/de/neuefische/readandmeet/backend/controller/BookCoverControllerTest.java
+++ b/backend/src/test/java/de/neuefische/readandmeet/backend/controller/BookCoverControllerTest.java
@@ -2,17 +2,26 @@ package de.neuefische.readandmeet.backend.controller;
 
 import de.neuefische.readandmeet.backend.model.BookCoverInfo;
 import de.neuefische.readandmeet.backend.service.BookCoverService;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.io.IOException;
+
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -24,18 +33,50 @@ class BookCoverControllerTest {
     @MockBean
     private BookCoverService bookCoverService;
 
+    private static MockWebServer mockWebServer;
+
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @DynamicPropertySource
+    static void backendProperties(DynamicPropertyRegistry registry) {
+        registry.add("bookcover-api.url", () -> mockWebServer.url("/").toString());
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        mockWebServer.shutdown();
+    }
+
     @Test
     void expectCoverInfo_whenFetchFirstCoverInfo() throws Exception {
-        // Arrange
+
         when(bookCoverService.fetchFirstCoverInfo(anyString(), anyString()))
                 .thenReturn(new BookCoverInfo(1234567, "https://covers.openlibrary.org/b/id/1234567-M.jpg"));
 
-        // Act & Assert
         mockMvc.perform(MockMvcRequestBuilders.get("/api/bookcover")
                         .param("title", "Test Title")
                         .param("author", "Test Author"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.coverId").value(1234567))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.coverUrl").value("https://covers.openlibrary.org/b/id/1234567-M.jpg"));
+
+
+        String response = """
+                        {
+                              "coverId": 1234567,
+                              "coverUrl": "https://covers.openlibrary.org/b/id/1234567-M.jpg"
+                          }
+                """;
+
+
+        mockWebServer.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(response));
+
     }
 }

--- a/backend/src/test/java/de/neuefische/readandmeet/backend/controller/BookCoverControllerTest.java
+++ b/backend/src/test/java/de/neuefische/readandmeet/backend/controller/BookCoverControllerTest.java
@@ -47,11 +47,6 @@ class BookCoverControllerTest {
         registry.add("bookcover-api.url", () -> mockWebServer.url("/").toString());
     }
 
-    @AfterAll
-    static void afterAll() throws IOException {
-        mockWebServer.shutdown();
-    }
-
     @Test
     void expectCoverInfo_whenFetchFirstCoverInfo() throws Exception {
 
@@ -78,5 +73,10 @@ class BookCoverControllerTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody(response));
 
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        mockWebServer.shutdown();
     }
 }

--- a/backend/src/test/java/de/neuefische/readandmeet/backend/controller/BookCoverControllerTest.java
+++ b/backend/src/test/java/de/neuefische/readandmeet/backend/controller/BookCoverControllerTest.java
@@ -1,0 +1,41 @@
+package de.neuefische.readandmeet.backend.controller;
+
+import de.neuefische.readandmeet.backend.model.BookCoverInfo;
+import de.neuefische.readandmeet.backend.service.BookCoverService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BookCoverControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BookCoverService bookCoverService;
+
+    @Test
+    void expectCoverInfo_whenFetchFirstCoverInfo() throws Exception {
+        // Arrange
+        when(bookCoverService.fetchFirstCoverInfo(anyString(), anyString()))
+                .thenReturn(new BookCoverInfo(1234567, "https://covers.openlibrary.org/b/id/1234567-M.jpg"));
+
+        // Act & Assert
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/bookcover")
+                        .param("title", "Test Title")
+                        .param("author", "Test Author"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.coverId").value(1234567))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.coverUrl").value("https://covers.openlibrary.org/b/id/1234567-M.jpg"));
+    }
+}

--- a/backend/src/test/java/de/neuefische/readandmeet/backend/model/BookCoverDocTest.java
+++ b/backend/src/test/java/de/neuefische/readandmeet/backend/model/BookCoverDocTest.java
@@ -1,0 +1,24 @@
+package de.neuefische.readandmeet.backend.model;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BookCoverDocTest {
+
+    @Test
+    public void testGetCoverId() {
+
+        // Given
+        BookCoverDoc bookCoverDoc = new BookCoverDoc();
+        Integer expectedCoverId = 42;
+        ReflectionTestUtils.setField(bookCoverDoc, "coverId", expectedCoverId);
+
+        //When
+        Integer actualCoverId = bookCoverDoc.getCoverId();
+
+        //Then
+        assertEquals(expectedCoverId, actualCoverId);
+    }
+}

--- a/backend/src/test/java/de/neuefische/readandmeet/backend/model/BookCoverDocTest.java
+++ b/backend/src/test/java/de/neuefische/readandmeet/backend/model/BookCoverDocTest.java
@@ -5,10 +5,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BookCoverDocTest {
+class BookCoverDocTest {
 
     @Test
-    public void testGetCoverId() {
+    void testGetCoverId() {
 
         // Given
         BookCoverDoc bookCoverDoc = new BookCoverDoc();

--- a/backend/src/test/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponseTest.java
+++ b/backend/src/test/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponseTest.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class OpenLibrarySearchResponseTest {
+class OpenLibrarySearchResponseTest {
 
     @Test
-    public void testGetDocs() {
+    void testGetDocs() {
 
         //Given
         List<BookCoverDoc> expectedDocs = new ArrayList<>();

--- a/backend/src/test/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponseTest.java
+++ b/backend/src/test/java/de/neuefische/readandmeet/backend/model/OpenLibrarySearchResponseTest.java
@@ -1,0 +1,32 @@
+package de.neuefische.readandmeet.backend.model;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenLibrarySearchResponseTest {
+
+    @Test
+    public void testGetDocs() {
+
+        //Given
+        List<BookCoverDoc> expectedDocs = new ArrayList<>();
+        BookCoverDoc doc1 = new BookCoverDoc();
+        doc1.setCoverId(1);
+        expectedDocs.add(doc1);
+        BookCoverDoc doc2 = new BookCoverDoc();
+        doc2.setCoverId(2);
+        expectedDocs.add(doc2);
+
+        OpenLibrarySearchResponse response = new OpenLibrarySearchResponse();
+        response.setDocs(expectedDocs);
+
+        //When
+        List<BookCoverDoc> actualDocs = response.getDocs();
+
+        //Then
+        assertEquals(expectedDocs, actualDocs);
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 de.flapdoodle.mongodb.embedded.version=6.0.1
+bookcover-api.url=https://openlibrary.org

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,34 +21,31 @@ export default function App() {
     const books = useStore((state) => state.books);
 
 
-
-
     return (
         <>
-        <main>
-            <Header />
-            <ToastContainer />
-            <Routes>
-                <Route path="/" element={<HomePage />} />
-                <Route path="/meetinglist" element={<MeetingList meetings={meetings} />} />
-                <Route path="/addmeeting" element={<AddMeetingPage />} />
-                <Route path="/meeting/:id" element={<DetailMeetingPage />} />
-                <Route path="/:id/editmeeting" element={<EditMeetingPage />} />
-                <Route path="/booklist" element={<BookList books={books}/>} />
-                <Route path="/addbook" element={<AddBookPage />} />
-                <Route path="/book/:id" element={<DetailBookPage />} />
-            </Routes>
+            <main>
+                <Header />
+                <ToastContainer />
+                <Routes>
+                    <Route path="/" element={<HomePage />} />
+                    <Route path="/meetinglist" element={<MeetingList meetings={meetings} />} />
+                    <Route path="/addmeeting" element={<AddMeetingPage />} />
+                    <Route path="/meeting/:id" element={<DetailMeetingPage />} />
+                    <Route path="/:id/editmeeting" element={<EditMeetingPage />} />
+                    <Route path="/booklist" element={<BookList books={books}/>} />
+                    <Route path="/addbook" element={<AddBookPage />} />
+                    <Route path="/book/:id" element={<DetailBookPage />} />
+                </Routes>
 
-        </main>
+            </main>
             <Paper className="navigation-paper">
                 <BottomNavigation sx={{ bgcolor: "#d1adee", height: "70px" }} showLabels>
                     <BottomNavigationAction label="Meetings" icon={<Groups />} style={{ color: 'black' }} component={Link} to="/meetinglist" />
                     <BottomNavigationAction label="Home" icon={<Home />} style={{ color: 'black' }} component={Link} to="/" />
                     <BottomNavigationAction label="Books" icon={<MenuBook />} style={{ color: 'black' }} component={Link} to="/booklist" />
-            </BottomNavigation>
+                </BottomNavigation>
             </Paper>
 
         </>
     );
 }
-

--- a/frontend/src/hooks/useStore.ts
+++ b/frontend/src/hooks/useStore.ts
@@ -16,6 +16,8 @@ type State = {
     getMeetingById: (id: string) => Meeting | undefined;
     deleteMeeting: (id: string) => void;
     putMeeting: (requestBody: Meeting) => void;
+    fetchBookCover: (title: string, author: string) => void;
+    bookCoverUrl: string;
 };
 
 export const useStore = create<State>((set, get) => ({
@@ -111,6 +113,25 @@ export const useStore = create<State>((set, get) => ({
                 }));
             })
             .catch(console.error);
+    },
+
+    bookCoverUrl: "",
+
+    fetchBookCover: (title: string, author: string): Promise<string> => {
+        const formattedTitle = title.trim().replace(/ /g, '+');
+        const formattedAuthor = author.trim().replace(/ /g, '+');
+        const apiUrl = `/api/bookcover?title=${formattedTitle}&author=${formattedAuthor}`;
+
+        return axios.get(apiUrl)
+            .then((response) => {
+                const coverUrl = response.data.coverUrl;
+                set({ bookCoverUrl: coverUrl });
+                return coverUrl;
+            })
+            .catch(error => {
+                console.error('Error fetching book cover:', error);
+                throw error;
+            });
     },
 
 }));

--- a/frontend/src/pages/DetailBookPage.tsx
+++ b/frontend/src/pages/DetailBookPage.tsx
@@ -1,10 +1,9 @@
 import {Card, CardContent, CardMedia, Rating, Typography} from "@mui/material";
 import {ChangeEvent, useEffect, useState} from 'react';
-import {Link, useNavigate, useParams} from 'react-router-dom';
+import {useNavigate, useParams} from 'react-router-dom';
 import {BookEditData, Status} from "../models/books.ts";
 import RatingHearts from "../components/RatingHearts.tsx";
 import {styled} from "styled-components";
-import Tooltip from '@mui/material/Tooltip';
 import 'react-toastify/dist/ReactToastify.css'
 import CardActionArea from "@mui/material/CardActionArea";
 import BorderColorIcon from "@mui/icons-material/BorderColor";
@@ -97,19 +96,15 @@ export default function DetailBookPage() {
                         justifyContent: "center",
                         alignItems: "center",
                     }}
-                    component={Link}
-                    to={`/book/${id}/cover`}
                 >
-                    <Tooltip title="Click to change cover" placement="bottom">
                     <CardMedia
                         component="img"
-                        height={228}
-                        width={170}
+                        height={270}
+                        width={180}
                         image={bookCoverUrl || "https://images.unsplash.com/photo-1534978184044-62700a717864?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80"}
                         alt="Book Cover"
                         style={{ margin: "8px" }}
                     />
-                </Tooltip>
                 </CardActionArea>
                 <CardContent
                     style={{

--- a/frontend/src/pages/DetailBookPage.tsx
+++ b/frontend/src/pages/DetailBookPage.tsx
@@ -1,10 +1,11 @@
 import {Card, CardContent, CardMedia, Rating, Typography} from "@mui/material";
-import {ChangeEvent, useState} from 'react';
-import {useNavigate, useParams} from 'react-router-dom';
+import {ChangeEvent, useEffect, useState} from 'react';
+import {Link, useNavigate, useParams} from 'react-router-dom';
 import {BookEditData, Status} from "../models/books.ts";
 import RatingHearts from "../components/RatingHearts.tsx";
 import {styled} from "styled-components";
-import 'react-toastify/dist/ReactToastify.css';
+import Tooltip from '@mui/material/Tooltip';
+import 'react-toastify/dist/ReactToastify.css'
 import CardActionArea from "@mui/material/CardActionArea";
 import BorderColorIcon from "@mui/icons-material/BorderColor";
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
@@ -18,7 +19,6 @@ import StatusSelect, {getStatusDisplay} from "../components/StatusSelect.tsx";
 import {getGenreDisplay} from "../components/GenreSelect.tsx";
 import ConfirmationDialog from "../components/ConfirmationDialog.tsx";
 
-
 export default function DetailBookPage() {
     const { id } = useParams();
     const book = useStore((state) => state.getBookById(id ?? ""));
@@ -31,6 +31,15 @@ export default function DetailBookPage() {
         status: book?.status ?? Status.NOT_READ,
         rating: book?.rating ?? 0,
     });
+
+    const fetchBookCover = useStore((state) => state.fetchBookCover);
+    const bookCoverUrl = useStore((state) => state.bookCoverUrl);
+
+    useEffect(() => {
+        if (book) {
+            fetchBookCover(book.title, book.author);
+        }
+    }, [book, fetchBookCover]);
 
     if (!book) {
         return <div>Book not found.</div>;
@@ -88,15 +97,19 @@ export default function DetailBookPage() {
                         justifyContent: "center",
                         alignItems: "center",
                     }}
+                    component={Link}
+                    to={`/book/${id}/cover`}
                 >
+                    <Tooltip title="Click to change cover" placement="bottom">
                     <CardMedia
                         component="img"
                         height={228}
                         width={170}
-                        image="https://images.unsplash.com/photo-1534978184044-62700a717864?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80"
+                        image={bookCoverUrl || "https://images.unsplash.com/photo-1534978184044-62700a717864?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80"}
                         alt="Book Cover"
-                        style={{ margin: "8px" }} // Set the desired margin
+                        style={{ margin: "8px" }}
                     />
+                </Tooltip>
                 </CardActionArea>
                 <CardContent
                     style={{


### PR DESCRIPTION
backend:

- implement webclient for Open Library API 
- add response, service and controller classes for webclient
- fetch book information (cover_i) using title and author as params
- use the coverId to get the image at covers.openlibrary.org
- add integration test for controller class

----

frontend:

- add state in useStore to fetch book covers
- use the title and author information in the detail book page component
- if there is no book cover fetch the default image is visible